### PR TITLE
Add install script for Element with Caddy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+Caddyfile
+docker-compose.yml
+/element/*
+!/element/.gitkeep

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # proxmox-lcx-support
+
+This repository contains helper scripts for deploying the Element web interface using Docker and serving it with Caddy.
+
+## Installation
+
+Run the install script with the hostname that should be used for automatic HTTPS certificates:
+
+```bash
+./scripts/install.sh example.com
+```
+
+The script generates a `Caddyfile` and `docker-compose.yml` configured to serve the Element static files.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOSTNAME=${1:-}
+
+if [ -z "$HOSTNAME" ]; then
+  echo "Usage: $0 <hostname>" >&2
+  exit 1
+fi
+
+cat > Caddyfile <<CADDY
+${HOSTNAME} {
+    root * /usr/share/nginx/html
+    file_server
+}
+CADDY
+
+cat > docker-compose.yml <<'COMPOSE'
+version: "3.8"
+services:
+  element:
+    image: vectorim/element-web:latest
+    volumes:
+      - ./element:/usr/share/nginx/html
+    restart: unless-stopped
+
+  caddy:
+    image: caddy:latest
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./element:/usr/share/nginx/html:ro
+    ports:
+      - "80:80"
+      - "443:443"
+    restart: unless-stopped
+COMPOSE
+
+printf "Caddyfile and docker-compose.yml generated.\n"


### PR DESCRIPTION
## Summary
- add install script to generate Caddyfile and docker compose
- add ignore rules and keep `element` directory
- document usage in README

## Testing
- `bash -n scripts/install.sh`

------
https://chatgpt.com/codex/tasks/task_e_68841d7cc8908332a76d795cac1959d0