### PR TITLE
Fix bootstrap response error handling

### DIFF
--- a/cmd/bootstrap-api/main.go
+++ b/cmd/bootstrap-api/main.go
@@ -3,7 +3,6 @@ package main
 import (
     "encoding/json"
     "fmt"
-    "io"
     "log"
     "net/http"
     "os"
@@ -59,11 +58,15 @@ func provision(w http.ResponseWriter, r *http.Request) {
     if err != nil {
         log.Println(err)
         w.WriteHeader(http.StatusInternalServerError)
-        io.WriteString(w, string(out))
+        if _, werr := w.Write(out); werr != nil {
+            log.Println("failed to write response body:", werr)
+        }
         return
     }
     resp := map[string]string{"vmid": vmid, "output": string(out)}
-    json.NewEncoder(w).Encode(resp)
+    if err := json.NewEncoder(w).Encode(resp); err != nil {
+        log.Println("failed to encode response:", err)
+    }
 }
 
 func main() {


### PR DESCRIPTION
## Summary
- check `w.Write` and `json.NewEncoder().Encode` errors in bootstrap API

## Testing
- `golangci-lint run ./...`

------
https://chatgpt.com/codex/tasks/task_e_68842a1d6eb08332a473915f515429b9